### PR TITLE
Added support for disabled cells

### DIFF
--- a/R/matrixInput.R
+++ b/R/matrixInput.R
@@ -19,6 +19,12 @@
 #' have the table element and the data object as argument}
 #'   \item{getHeader}{same as createHeader but with table element as only argument}
 #' }
+#' 
+#' Similarly, the parameter `cells` takes a list of arguments:
+#' 
+#' \describe{
+#'   \item{editableCells}{logical, should cells be editable (default `TRUE`)}
+#' }
 #'
 #' @param inputId The input slot that will be used to access the value
 #' @param label label for input field
@@ -49,6 +55,7 @@ matrixInput <- function(inputId,
                         inputClass = "",
                         rows = list(),
                         cols = list(),
+                        cells = list(),
                         class = "character",
                         paste = FALSE,
                         copy = FALSE,
@@ -66,6 +73,7 @@ matrixInput <- function(inputId,
 
   rows <- default(rows, list(names = TRUE, editableNames = FALSE, extend = FALSE, delta = 1))
   cols <- default(cols, list(names = TRUE, editableNames = FALSE, extend = FALSE, delta = 1))
+  cells <- default(cells, list(editableCells = TRUE))
 
   inputField <- tags$div(
     id = inputId,
@@ -75,6 +83,7 @@ matrixInput <- function(inputId,
     "data-colnames" = jsonlite::toJSON(colnames(value)),
     "data-rows" = jsonlite::toJSON(rows, auto_unbox = TRUE),
     "data-cols" = jsonlite::toJSON(cols, auto_unbox = TRUE),
+    "data-cells" = jsonlite::toJSON(cells, auto_unbox = TRUE),
     "data-class" = jsonlite::toJSON(class, auto_unbox = FALSE),
     "data-pagination" = jsonlite::toJSON(pagination, auto_unbox = TRUE),
     "data-lazy" = jsonlite::toJSON(lazy, auto_unbox = TRUE),

--- a/inst/www/matrix-input.js
+++ b/inst/www/matrix-input.js
@@ -1,6 +1,6 @@
 /* Vue */
 Vue.component('matrix-input', {
-    props: ["values", "rownames", "colnames", "rows", "cols", "pagination", "content_class", "multiheader"],
+    props: ["values", "rownames", "colnames", "rows", "cols", "cells", "pagination", "content_class", "multiheader"],
     data () {
       return {
         focus: {
@@ -63,7 +63,7 @@ Vue.component('matrix-input', {
             <matrix-header-cell :value="(rownames[i] || '')" :i="i" type="row" :focus="focus"
             :config="rows" header="0" v-if="rows.names === true"/>
             <matrix-cell v-for="(v, j) in values[i]" :key="j" :value="v" :i="i" :j="j" :focus="focus"
-            :content_class="content_class"/>
+            :content_class="content_class" :config="cells"/>
           </tr>
         </table>
         <div class="pagination" v-if="pagination">
@@ -127,7 +127,7 @@ Vue.component('matrix-input', {
 })
 
 Vue.component('matrix-cell', {
-    props: ["value", "i", "j", "focus", "content_class"],
+    props: ["value", "i", "j", "focus", "config", "content_class"],
     data () {
        return {
            input_value: this.value
@@ -141,7 +141,7 @@ Vue.component('matrix-cell', {
       }
     },
     template: `
-    <td @mousedown="select" :class="{active: in_focus}">
+    <td @mousedown="select" :class="{active: in_focus, editable: config.editableCells}">
       <input ref="input" v-if="in_focus" v-model="input_value" @blur="update"
       v-on:keydown.enter.exact="next_row"
       v-on:keydown.shift.enter="previous_row"
@@ -166,6 +166,7 @@ Vue.component('matrix-cell', {
         this.$root.$emit('update_cell', {value: this.input_value, i: this.i, j: this.j})
       },
       select (e) {
+        if (!this.config.editableCells) return;
         if (!this.in_focus) {
           let inputs = this.$root.$el.getElementsByTagName("input");
           if (inputs.length > 0) inputs[0].blur();
@@ -359,6 +360,7 @@ $.extend(matrixInput, {
             colnames: $(el).data("colnames"),
             rows: $(el).data("rows"),
             cols: $(el).data("cols"),
+            cells: $(el).data("cells"),
             content_class: $(el).data("class")[0],
             pagination: $(el).data("pagination")
         },
@@ -419,7 +421,7 @@ $.extend(matrixInput, {
         },
         template: `
           <matrix-input :values="extended_values" :rownames="extended_rownames" :colnames="extended_colnames"
-          :rows="rows" :cols="cols" :pagination="pagination" :content_class="content_class"
+          :rows="rows" :cols="cols" :cells="cells" :pagination="pagination" :content_class="content_class"
           />
         `
     })

--- a/man/matrixInput.Rd
+++ b/man/matrixInput.Rd
@@ -11,6 +11,7 @@ matrixInput(
   inputClass = "",
   rows = list(),
   cols = list(),
+  cells = list(),
   class = "character",
   paste = FALSE,
   copy = FALSE,
@@ -65,6 +66,12 @@ are supported:
 default function to create/update table header. The function needs to
 have the table element and the data object as argument}
   \item{getHeader}{same as createHeader but with table element as only argument}
+}
+
+Similarly, the parameter `cells` takes a list of arguments:
+
+\describe{
+  \item{editableCells}{logical, should cells be editable (default `TRUE`)}
 }
 }
 \examples{


### PR DESCRIPTION
A possible solution to disabling cells as stated in #26 

In an attempt to keep it flexible, I stuck to the structure of the `cols` and `rows` parameter. Optimally, I would like to extend the feature to be able to execute callback functions when a cell is clicked. To do this, however, I would first want to hear your opinion if this is even a desirable functionality to have in this package, or if it should be structured differently. I also realize that the documentation could be a little confusing, as `cols`, `rows`, and `cells` are so similar.

Alternatively, it would also make sense to incorporate `shinyjs` for disabling and enabling inputs.

Nevertheless, with this pull request, here is an example shiny application with disabled cells.

```{R}
library(shinyMatrix)

m <- diag(5)

shiny::tagList(
  shiny::fluidPage(
    shiny::titlePanel("Demonstration Matrix Input Field"),
    shiny::fluidRow(
      column(6, matrixInput(
        inputId = "matrix",
        label = "Default matrix",
        value = m,
        class = "numeric",
        cols = list(
          names = TRUE
        ),
        rows = list(
          names = TRUE
        ),
        cells = list(editableCells = FALSE)
      )),
      column(6, tableOutput("table"))
    )
  )
)
```