### PR TITLE
CRAN Release 0.8.1 - update Roxygen to 7.3.2, update Date & NEWS.md

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,4 +13,4 @@ Imports: shiny,
 Suggests: testthat,
     covr
 RoxygenNote: 7.3.2
-URL: https://inwtlab.github.io/shiny-matrix/
+URL: https://inwtlab.github.io/shinyMatrix/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,11 @@
 Package: shinyMatrix
 Title: Shiny Matrix Input Field 
 Version: 0.8.1
-Date: 2026-02-26
-Author: Andreas Neudecker
-Maintainer: Andreas Neudecker <andreas.neudecker@inwt-statistics.de>
+Date: 2026-03-05
+Authors@R: person(given = "Andreas",
+                  family = "Neudecker",
+                  role = c("aut", "cre"),
+                  email = "andreas.neudecker@inwt-statistics.de")
 Description: Implements a custom matrix input field. 
 Depends: R (>= 3.5)
 License: MIT + file LICENSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: shinyMatrix
 Title: Shiny Matrix Input Field 
 Version: 0.8.1
-Date: 2024-04-10
+Date: 2026-02-26
 Author: Andreas Neudecker
 Maintainer: Andreas Neudecker <andreas.neudecker@inwt-statistics.de>
 Description: Implements a custom matrix input field. 
@@ -12,5 +12,5 @@ Imports: shiny,
   jsonlite
 Suggests: testthat,
     covr
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 URL: https://inwtlab.github.io/shiny-matrix/

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# ShinyMatrix 0.8.1
+
+* Make matrixInputs' labels' classes like other Shiny inputs'
+
 # ShinyMatrix 0.8.0
 
 * Add parameter to format cells

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Matrix Input for Shiny
 
-[![R-CMD-check](https://github.com/INWTlab/shiny-matrix/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/INWTlab/shiny-matrix/actions/workflows/R-CMD-check.yaml)
-[![Coverage Status](https://img.shields.io/codecov/c/github/INWTlab/shiny-matrix/master.svg)](https://app.codecov.io/github/INWTlab/shiny-matrix?branch=master)
+[![R-CMD-check](https://github.com/INWTlab/shinyMatrix/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/INWTlab/shinyMatrix/actions/workflows/R-CMD-check.yaml)
+[![Coverage Status](https://img.shields.io/codecov/c/github/INWTlab/shinyMatrix/master.svg)](https://app.codecov.io/github/INWTlab/shinyMatrix?branch=master)
 [![CRAN status](https://www.r-pkg.org/badges/version/shinyMatrix)](https://cran.r-project.org/package=shinyMatrix)
 
 # Matrix Input for Shiny
 
 This package provides an input field to enter matrix conveniently in a shiny application. It supports tabbing and jumping linewise in the matrix.
 
-![Screenshot Simple Matrix](https://github.com/INWTlab/shiny-matrix/raw/master/screenshot1.png)
+![Screenshot Simple Matrix](https://github.com/INWTlab/shinyMatrix/raw/master/screenshot1.png)
 
 ## Installation
 From CRAN:
@@ -18,7 +18,7 @@ install.packages("shinyMatrix")
 From GitHub:
 
 ```r
-if (require("devtools")) install_github("INWTlab/shiny-matrix")
+if (require("devtools")) install_github("INWTlab/shinyMatrix")
 ```
 
 ## Usage

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://inwtlab.github.io/shiny-matrix/
+url: https://inwtlab.github.io/shinyMatrix/
 template:
   bootstrap: 5
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,14 +1,10 @@
 ## R CMD check results
-
+On local Pop!_OS 24.04 LTS, R 4.5.2:
 0 errors ✔ | 0 warnings ✔ | 0 notes ✔
 
-## Updates in 0.8.0
+## Submission summary
+This is a patch release
 
- * Add parameter to format cells
+## Updates in 0.8.1
 
-## Updates in 0.7.0
- * Fix: Bug when using extend feature for rows in the matrix #21
- * Feature: Change or disable click behavior #26
- * Improve tabbing and extension functionality
- * Online Documentation (pkgdown) & R-CMD Check
-
+* Make matrixInputs' labels' classes like other Shiny inputs for better UI consistency.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -8,3 +8,10 @@ This is a patch release
 ## Updates in 0.8.1
 
 * Make matrixInputs' labels' classes like other Shiny inputs for better UI consistency.
+
+## Resubmission
+
+The previous submission was flagged for a missing Authors@R field.
+
+## Changes
+* Replaced Author and Maintainer fields with Authors@R in DESCRIPTION as requested by CRAN.


### PR DESCRIPTION
see https://github.com/INWTlab/shinyMatrix/issues/44

`0.8.1` was submitted to CRAN.